### PR TITLE
Cambie el status por default del model Post a 'pending_approval', agr…

### DIFF
--- a/prisma/migrations/20250525194924_add_pending_approval_to_enum/migration.sql
+++ b/prisma/migrations/20250525194924_add_pending_approval_to_enum/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "PostStatus" ADD VALUE 'pending_approval';

--- a/prisma/migrations/20250525195129_set_default_post_status_to_pending_approval/migration.sql
+++ b/prisma/migrations/20250525195129_set_default_post_status_to_pending_approval/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Post" ALTER COLUMN "status" SET DEFAULT 'pending_approval';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,7 +69,7 @@ model Post {
   id            Int       @id @default(autoincrement())
   title         String    @db.VarChar(255)
   content       String    @db.Text
-  status        PostStatus @default(published)
+  status        PostStatus @default(pending_approval)
   created_at    DateTime  @default(now())
   updated_at    DateTime  @updatedAt
   user_id       Int
@@ -121,6 +121,7 @@ model RolePermission {
 enum PostStatus {
   draft
   published
+  pending_approval
 }
 
 enum CategoryType {

--- a/src/controllers/post.controller.js
+++ b/src/controllers/post.controller.js
@@ -8,10 +8,9 @@ import {
 
 export const createPost = async (req, res, next) => {
   try {
-    const { title, content, category_id } = req.body
+    const { title, content, category_id, community_id } = req.body
 
     const user_id = req.user.id
-    const community_id = req.user.community_id || null
 
     const newPost = await createPostService({
       title,

--- a/src/schemas/posts.schema.js
+++ b/src/schemas/posts.schema.js
@@ -4,6 +4,8 @@ export const createPostSchema = z.object({
   title: z.string().min(1, { message: 'El título es requerido' }),
   content: z.string().min(1, { message: 'El contenido es requerido' }),
   category_id: z.number({ message: 'La categoría es requerida' }),
+  community_id: z.number().optional(),
+  status: z.enum(['draft', 'published', 'pending_approval']).optional(), // Hacer que sea opcional
 })
 
 export const updatePostSchema = createPostSchema.partial()


### PR DESCRIPTION
…egue el nuevo enum 'pending_approval', y modifique el servicio de post para crear un post, porque si no enviaba una community_id, por defecto me enviaba 1, entonces deje por defecto la del user que esta creando el post. Es decir si users en su registro community_id es 2, y cuando crea un post si no envia community_id, entonces por default sera 2.